### PR TITLE
Update pyo3_template.py

### DIFF
--- a/rustimport/pre_processing/pyo3_template.py
+++ b/rustimport/pre_processing/pyo3_template.py
@@ -37,6 +37,7 @@ class PyO3Template(Template):
         structs = re.finditer(rb'#\[pyclass]\s*(?:\w\s+)*?struct\s+([\w0-9]+)', self.contents, re.MULTILINE)
 
         res = [
+            b'#![feature(const_fn_trait_bound)]',
             b'#[pymodule]',
             b'fn ' + self.lib_name.encode() + b'(_py: Python, m: &PyModule) -> PyResult<()> {',
             *[


### PR DESCRIPTION
Fixes `error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable`