### PR TITLE
Replace hashlib.sha1 with hashlib.new to ensure compatibility with Python 3.8

### DIFF
--- a/rustimport/checksum.py
+++ b/rustimport/checksum.py
@@ -87,7 +87,7 @@ def _calc_cur_checksum(file_patterns: List[str], hasher=settings.checksum_hasher
     for filepath in sorted(all_files):
         with open(filepath, "rb") as f:
             if not any(c[0] == filepath for c in checksums):
-                checksums.append((filepath, hasher(f.read(), usedforsecurity=False).hexdigest()))
+                checksums.append((filepath, hasher(f.read()).hexdigest()))
 
     payload = '\n'.join(
         f'{p}:{c}' for p, c in checksums
@@ -96,4 +96,4 @@ def _calc_cur_checksum(file_patterns: List[str], hasher=settings.checksum_hasher
     if release:
         payload = b"r\n" + payload
 
-    return hasher(payload, usedforsecurity=False).hexdigest().encode()
+    return hasher(payload).hexdigest().encode()

--- a/rustimport/settings.py
+++ b/rustimport/settings.py
@@ -2,7 +2,6 @@ import hashlib
 import os
 import tempfile
 from typing import Optional
-import functools
 
 force_rebuild: bool = os.getenv("RUSTIMPORT_FORCE_REBUILD", "0").lower() in ("true", "yes", "1")
 """
@@ -59,7 +58,7 @@ directory does not exist, it'll be created automatically.
 Env var: `RUSTIMPORT_CACHE_DIR=<directory path>`
 """
 
-checksum_hasher = functools.partial(hashlib.new, 'sha1', usedforsecurity=False)
+checksum_hasher = hashlib.sha1
 """
 Specify the hash function to use for hashing. This function should be compatible with all the named
 constructors from `hashlib` (e.g. `hashlib.md5(...)`  or `hashlib.sha256(...)`).

--- a/rustimport/settings.py
+++ b/rustimport/settings.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import tempfile
 from typing import Optional
+import functools
 
 force_rebuild: bool = os.getenv("RUSTIMPORT_FORCE_REBUILD", "0").lower() in ("true", "yes", "1")
 """
@@ -58,7 +59,7 @@ directory does not exist, it'll be created automatically.
 Env var: `RUSTIMPORT_CACHE_DIR=<directory path>`
 """
 
-checksum_hasher = hashlib.sha1
+checksum_hasher = functools.partial(hashlib.new, 'sha1', usedforsecurity=False)
 """
 Specify the hash function to use for hashing. This function should be compatible with all the named
 constructors from `hashlib` (e.g. `hashlib.md5(...)`  or `hashlib.sha256(...)`).


### PR DESCRIPTION
Thanks for the great package! I tried to run this on macOS on Python 3.8, but it failed because `hashlib.sha1` in this environment doesn't have a "usedforsecurity" argument. Replacing the named constructor with the `new` constructor, and specifying "usedforsecurity" in it, solves the problem.

Note: The Python [docs](https://docs.python.org/3/library/hashlib.html#hashlib.new) do say that named constructors should be preferred as they are "much faster".