### PR TITLE
Backwards compatible type hints

### DIFF
--- a/rustimport/import_hook.py
+++ b/rustimport/import_hook.py
@@ -45,7 +45,7 @@ class Loader(importlib.abc.Loader):
     def __init__(self, importable: Importable):
         self.__importable = importable
 
-    def create_module(self, spec: ModuleSpec) -> types.ModuleType | None:
+    def create_module(self, spec: ModuleSpec) -> Optional[types.ModuleType]:
         if should_rebuild(self.__importable):
             self.__importable.build(release=settings.compile_release_binaries)
         return self.__importable.load()


### PR DESCRIPTION
Replaced `types.ModuleType | None` with `Optional[types.ModuleType]` as the other syntax is incompatible with Python < 3.10. Feel free to close this if it's easier to add it yourself. This was broken by commit 66e2716124c132449efdd3f9b66c648991b5a7f8.