### PR TITLE
Resolved infinite loop for crate builds on Windows

### DIFF
--- a/rustimport/importable.py
+++ b/rustimport/importable.py
@@ -161,9 +161,9 @@ class CrateImportable(Importable):
     @cached_property
     def __workspace_path(self) -> Optional[str]:
         """Returns the path of the cargo workspace this crate belongs to, if there is any."""
-
+        root_dir = os.path.abspath(".").split(os.path.sep)[0] + os.path.sep
         p = self.__crate_path
-        while os.path.dirname(p) != os.path.sep:  # loop through all parent directories...
+        while os.path.dirname(p) != root_dir:  # loop through all parent directories...
             p = os.path.dirname(p)
 
             if os.path.isfile(os.path.join(p, "Cargo.toml")):  # ... and check for a "Cargo.toml" file in each of them.


### PR DESCRIPTION
This bug was introduced when cargo workspace support was introduced.

os.path.sep is "/" or "\", which is fine for linux's root directory, but not windows. It would just keep returning "C:\\" which isn't "/", resulting in an infinite while loop for any crate build. 

The new check should be fully portable, even with different drive names.