### PR TITLE
added compatibility with explicit function signatures

### DIFF
--- a/rustimport/pre_processing/pyo3_template.py
+++ b/rustimport/pre_processing/pyo3_template.py
@@ -36,7 +36,9 @@ class PyO3Template(Template):
 
     def __generate_pymodule(self) -> bytes:
         # A rather rudimentary implementation of generating PyO3 the "pymodule" macro's contents
-        functions = re.finditer(rb'#\[pyfunction]\s*(?:\w+\s+)*?fn\s+([\w0-9]+)', self.contents, re.MULTILINE)
+        functions = re.finditer(
+        rb'#\[pyfunction.*\s*(?:\w+\s+)*?(?:#\[pyo3.*)?\s*(?:\w+\s+)*?fn\s+([\w0-9]+)', self.contents, re.MULTILINE
+        )
         structs = re.finditer(rb'#\[pyclass]\s*(?:\w+\s+)*?(?:struct|enum)\s+([\w0-9]+)', self.contents, re.MULTILINE)
 
         res = [


### PR DESCRIPTION
just a quick (non-breaking) regex change to match both the "modern" (>=0.18.0) and depreciated [function signature](https://pyo3.rs/v0.18.3/function/signature) forms. 

`rustimport new` uses pyo3 0.16.2 but this forward compatibility shouldn't break anything there.


![image](https://user-images.githubusercontent.com/39544927/233830720-5fa46441-65e7-4f3e-9560-af232d7453af.png)
(Top to bottom: No explicit function signature; >=0.18.0 function signature; depreciated function signature)