### PR TITLE
Normalize the `manifest_path` before comparison with `abs_crate_path`

### DIFF
--- a/rustimport/compiler.py
+++ b/rustimport/compiler.py
@@ -102,7 +102,8 @@ class Cargo:
                 messages.append(message := json.loads(line))
 
                 if message.get('reason') == 'compiler-artifact':
-                    if os.path.dirname(message.get('manifest_path')) == abs_crate_path:
+                    manifest_path = os.path.realpath(message.get('manifest_path'))
+                    if os.path.dirname(manifest_path) == abs_crate_path:
                         artifact_path = message['filenames'][0]
                 elif message.get('reason') == 'compiler-message':
                     if not proc.stderr:


### PR DESCRIPTION
We have to normalize `manifest_path` the same way we already normalized the `abs_crate_path`
before comparing them.

Without this fix, I cannot use rustimport on my windows developer machine. As the `manifest_path` that we get from the rust output, is a path in a short form `C:\Users\MHAND~1.BOU....`