### PR TITLE
Fix infinite loop in Windows by Normalizing the `root_dir` before comparison

### DIFF
--- a/rustimport/importable.py
+++ b/rustimport/importable.py
@@ -161,7 +161,7 @@ class CrateImportable(Importable):
     @cached_property
     def __workspace_path(self) -> Optional[str]:
         """Returns the path of the cargo workspace this crate belongs to, if there is any."""
-        root_dir = os.path.abspath(".").split(os.path.sep)[0] + os.path.sep
+        root_dir = os.path.realpath(".").split(os.path.sep)[0] + os.path.sep
         p = self.__crate_path
         while os.path.dirname(p) != root_dir:  # loop through all parent directories...
             p = os.path.dirname(p)


### PR DESCRIPTION
We normalize `root_dir` before using it for comparison.
Another solution would be to avoid comparing path with `!=` or `==`
and use `os.path.samefile()` 

For now, I have followed the "normalization" approach the project is currently using.
but feel free to consider `os.path.samefile()` as it would not need any normalization upfront.